### PR TITLE
fix: double escape forward slash

### DIFF
--- a/default.json
+++ b/default.json
@@ -46,7 +46,7 @@
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
       "matchStrings": ["\\s+.+download-actionlint\\.bash\\)? (?<currentValue>.+)"],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "rhysd\/actionlint",
+      "depNameTemplate": "rhysd\\/actionlint",
       "extractVersionTemplate": "^v?(?<version>.*)$",
       "versioningTemplate": "semver"
     }

--- a/default.json
+++ b/default.json
@@ -47,8 +47,7 @@
       "matchStrings": ["\\s+.+download-actionlint\\.bash\\)? (?<currentValue>.+)"],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "rhysd\\/actionlint",
-      "extractVersionTemplate": "^v?(?<version>.*)$",
-      "versioningTemplate": "semver"
+      "extractVersionTemplate": "^v?(?<version>.*)$"
     }
   ],
   "enabledManagers": ["dockerfile", "github-actions", "npm", "nvm", "regex"]


### PR DESCRIPTION
And `semver` is Renovate's default versioning.