### PR TITLE
refactor: exclude TypeScript from weekly npm group

### DIFF
--- a/default.json
+++ b/default.json
@@ -20,7 +20,7 @@
       "extends": ["schedule:weekly"],
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
-      "excludePackageNames": ["yarn"],
+      "excludePackageNames": ["typescript", "yarn"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
     },


### PR DESCRIPTION
Since they do not follow semver, this is a good idea as minor upgrades may include breaking changes.